### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+# 1.1.1
+
+- Adds key in `CubeWidget`
+
 # 1.1.0
 
-- Add `SimpleCube`
+- Adds `SimpleCube`
 - Update `GetIt`
-- Add `Cubes.registerDependencyAsync`
-- Add `Cubes.getDependencyAsync`
+- Adds `Cubes.registerDependencyAsync`
+- Adds `Cubes.getDependencyAsync`
 - improvements in `CubeStateMixin`
 
 # 1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.1.1
+# 1.2.0
 
 - Adds key in `CubeWidget`
+- Update README.md
 - BREAKING CHANGES: remove bool to indicate type of the register dependency.
 Now use enum `DependencyRegisterType` between `factory`, `singleton`, `lazySingleton`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.1.1
 
 - Adds key in `CubeWidget`
+- BREAKING CHANGES: remove bool to indicate type of the register dependency.
+Now use enum `DependencyRegisterType` between `factory`, `singleton`, `lazySingleton`.
 
 # 1.1.0
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,8 +21,14 @@ import 'text_form_field/text_form_field_cube.dart';
 void main() {
   // register cube
   Cubes.registerDependency((i) => CounterCube());
-  Cubes.registerDependency((i) => CounterSingletonCube(), isSingleton: true);
-  Cubes.registerDependency((i) => TodoCube(), isSingleton: true);
+  Cubes.registerDependency(
+    (i) => CounterSingletonCube(),
+    type: DependencyRegisterType.singleton,
+  );
+  Cubes.registerDependency(
+    (i) => TodoCube(),
+    type: DependencyRegisterType.singleton,
+  );
   Cubes.registerDependency((i) => PokemonCube(i.getDependency()));
   Cubes.registerDependency((i) => PokemonRepository());
   Cubes.registerDependency((i) => FeedbackManagerCube());

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -119,7 +119,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   dart_style:
     dependency: transitive
     description:

--- a/lib/cubes.dart
+++ b/lib/cubes.dart
@@ -47,12 +47,12 @@ class Cubes {
   static void registerDependency<T extends Object>(
     CDependencyInjectorBuilder<T> builder, {
     String? dependencyName,
-    bool isSingleton = false,
+    DependencyRegisterType type = DependencyRegisterType.factory,
   }) {
     _instance._injector.registerDependency<T>(
       builder,
       dependencyName: dependencyName,
-      isSingleton: isSingleton,
+      type: type,
     );
   }
 
@@ -60,12 +60,12 @@ class Cubes {
   static void registerDependencyAsync<T extends Object>(
     CDependencyInjectorAsyncBuilder<T> builder, {
     String? dependencyName,
-    bool isSingleton = false,
+    DependencyRegisterType type = DependencyRegisterType.factory,
   }) {
     _instance._injector.registerDependencyAsync<T>(
       builder,
       dependencyName: dependencyName,
-      isSingleton: isSingleton,
+      type: type,
     );
   }
 

--- a/lib/src/injector/get_it_injector.dart
+++ b/lib/src/injector/get_it_injector.dart
@@ -15,26 +15,27 @@ class GetItInjector extends CInjector {
   void registerDependency<T extends Object>(
     CDependencyInjectorBuilder<T> builder, {
     String? dependencyName,
-    bool isSingleton = false,
-    bool isSingletonLazy = true,
+    DependencyRegisterType type = DependencyRegisterType.factory,
   }) {
-    if (isSingleton) {
-      if (isSingletonLazy) {
-        _getIt.registerLazySingleton<T>(
+    switch (type) {
+      case DependencyRegisterType.factory:
+        _getIt.registerFactory<T>(
           () => builder(this),
           instanceName: dependencyName,
         );
-      } else {
+        break;
+      case DependencyRegisterType.singleton:
         _getIt.registerSingleton<T>(
           builder(this),
           instanceName: dependencyName,
         );
-      }
-    } else {
-      _getIt.registerFactory<T>(
-        () => builder(this),
-        instanceName: dependencyName,
-      );
+        break;
+      case DependencyRegisterType.lazySingleton:
+        _getIt.registerLazySingleton<T>(
+          () => builder(this),
+          instanceName: dependencyName,
+        );
+        break;
     }
   }
 
@@ -47,26 +48,27 @@ class GetItInjector extends CInjector {
   void registerDependencyAsync<T extends Object>(
     CDependencyInjectorAsyncBuilder<T> builder, {
     String? dependencyName,
-    bool isSingleton = false,
-    bool isSingletonLazy = true,
+    DependencyRegisterType type = DependencyRegisterType.factory,
   }) {
-    if (isSingleton) {
-      if (isSingletonLazy) {
+    switch (type) {
+      case DependencyRegisterType.factory:
+        _getIt.registerFactoryAsync<T>(
+          () => builder(this),
+          instanceName: dependencyName,
+        );
+        break;
+      case DependencyRegisterType.singleton:
         _getIt.registerLazySingletonAsync<T>(
           () => builder(this),
           instanceName: dependencyName,
         );
-      } else {
+        break;
+      case DependencyRegisterType.lazySingleton:
         _getIt.registerSingletonAsync<T>(
           () => builder(this),
           instanceName: dependencyName,
         );
-      }
-    } else {
-      _getIt.registerFactoryAsync<T>(
-        () => builder(this),
-        instanceName: dependencyName,
-      );
+        break;
     }
   }
 

--- a/lib/src/injector/injector.dart
+++ b/lib/src/injector/injector.dart
@@ -1,3 +1,6 @@
+/// Enum that represents types of the register
+enum DependencyRegisterType { factory, singleton, lazySingleton }
+
 /// Function to receive dependency to inject
 typedef CDependencyInjectorBuilder<T> = T Function(CInjector injector);
 
@@ -12,16 +15,14 @@ abstract class CInjector {
   void registerDependency<T extends Object>(
     CDependencyInjectorBuilder<T> builder, {
     String? dependencyName,
-    bool isSingleton = false,
-    bool isSingletonLazy = true,
+    DependencyRegisterType type = DependencyRegisterType.factory,
   });
 
   /// Method used to register dependency async
   void registerDependencyAsync<T extends Object>(
     CDependencyInjectorAsyncBuilder<T> builder, {
     String? dependencyName,
-    bool isSingleton = false,
-    bool isSingletonLazy = true,
+    DependencyRegisterType type = DependencyRegisterType.factory,
   });
 
   /// Method used to get dependency

--- a/lib/src/widgets/cube_builder.dart
+++ b/lib/src/widgets/cube_builder.dart
@@ -11,7 +11,7 @@ typedef AsyncCubeWidgetBuilder<C extends Cube> = Widget Function(
 );
 
 typedef InitCallback<C extends Cube> = Function(C cube);
-typedef CubeWidgetDispose<C extends Cube> = bool Function(C? cube);
+typedef CubeWidgetDispose<C extends Cube> = bool Function(C cube);
 
 /// Widget responsible for getting instance and providing Cube
 class CubeBuilder<C extends Cube> extends StatefulWidget {

--- a/lib/src/widgets/cube_widget.dart
+++ b/lib/src/widgets/cube_widget.dart
@@ -6,12 +6,14 @@ import '../cube.dart';
 /// Widget created to replace StatelessWidget and facilitate the use of Cube
 /// This is responsible for getting instance and providing Cube
 abstract class CubeWidget<C extends Cube> extends StatelessWidget {
+  const CubeWidget({Key? key}) : super(key: key);
+
   /// called when cube send any Action to view.
   // ignore: no-empty-block
   void onAction(BuildContext context, C cube, CubeAction action) {}
 
   /// if you want the widget to not call `dispose` in the Cube, return false
-  bool dispose(C? cube) => true;
+  bool dispose(C cube) => true;
 
   /// Arguments that will be sent to the cube through the onReady () method
   /// If this argument is not set,

--- a/lib/src/widgets/observer.dart
+++ b/lib/src/widgets/observer.dart
@@ -49,11 +49,14 @@ class _CObserverState<T> extends State<CObserver> with StateMixin {
       return AnimatedSwitcher(
         duration: widget.duration,
         transitionBuilder: widget.transitionBuilder,
-        child: widgetObserver.builder(widget.observable.value) ??
-            SizedBox.shrink(),
+        child: _buildChild(),
       );
     }
 
+    return _buildChild();
+  }
+
+  Widget _buildChild() {
     return widgetObserver.builder(widget.observable.value) ?? SizedBox.shrink();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cubes
 description: Simple State Manager (Focusing on simplicity and rebuilding only the necessary)
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/RafaelBarbosatec/cube
 
 environment:

--- a/test/injector/get_it_injector_test.dart
+++ b/test/injector/get_it_injector_test.dart
@@ -32,22 +32,21 @@ void main() {
 
         return 'count: $_counter';
       },
-      isSingleton: true,
+      type: DependencyRegisterType.singleton,
     );
     expect(injector.getDependency<String>(), 'count: 1');
     expect(injector.getDependency<String>(), 'count: 1');
     expect(injector.getDependency<String>(), 'count: 1');
   });
 
-  test('verify return injected singleton not lazy', () {
+  test('verify return injected singleton lazy', () {
     injector.registerDependency<String>(
       (injector) {
         _counter++;
 
         return 'count: $_counter';
       },
-      isSingleton: true,
-      isSingletonLazy: false,
+      type: DependencyRegisterType.lazySingleton,
     );
     expect(injector.getDependency<String>(), 'count: 1');
     expect(injector.getDependency<String>(), 'count: 1');
@@ -75,7 +74,7 @@ void main() {
 
         return 'count: $_counter';
       },
-      isSingleton: true,
+      type: DependencyRegisterType.singleton,
     );
 
     final r1 = await injector.getDependencyAsync<String>();
@@ -85,7 +84,7 @@ void main() {
     expect(r2, 'count: 1');
   });
 
-  test('verify return injected singleton async not lazy', () async {
+  test('verify return injected singleton async lazy', () async {
     injector.registerDependencyAsync<String>(
       (injector) async {
         await Future.delayed(Duration(seconds: 1));
@@ -93,8 +92,7 @@ void main() {
 
         return 'count: $_counter';
       },
-      isSingleton: true,
-      isSingletonLazy: false,
+      type: DependencyRegisterType.lazySingleton,
     );
 
     final r1 = await injector.getDependencyAsync<String>();


### PR DESCRIPTION
- Adds key in `CubeWidget`
- Update README.md
- BREAKING CHANGES: remove bool to indicate type of the register dependency.
Now use enum `DependencyRegisterType` between `factory`, `singleton`, `lazySingleton`.
